### PR TITLE
Support custom color for the cursor flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ it and just execute the command as follows when you need it.
 
 ## Configuration
 
-The duration of the cursor flash can be customized in your `~/.vimrc`:
+The duration and color of the cursor flash can be customized in your `~/.vimrc`:
 
-    " This is the default
+    " This is the default duration
     let g:ping_cursor_flash_milliseconds = 250
+    " Set named color to the cursor flash 
+    let g:ping_cursor_color = 'lightblue'
 
 ## Why I Built This
 

--- a/plugin/vim-ping-cursor.vim
+++ b/plugin/vim-ping-cursor.vim
@@ -16,10 +16,25 @@ if !exists('g:ping_cursor_flash_milliseconds')
 endif
 
 function! s:PingCursor()
+  " Save current CursorLine and CursorColumn attributes
+  let l:cur_cursorline = matchstr(execute('hi CursorLine'), 'term=.*')
+  let l:cur_cursorcolumn = matchstr(execute('hi CursorColumn'), 'term=.*')
+
+  " Flash
+  highlight CursorLine ctermbg=lightblue guibg=lightblue
+  highlight CursorColumn ctermbg=lightblue guibg=lightblue
   set cursorline cursorcolumn
   redraw
   execute 'sleep' g:ping_cursor_flash_milliseconds . 'm'
   set nocursorline nocursorcolumn
+
+  " Restore previous highlight attributes
+  if !empty(l:cur_cursorline)
+    execute 'highlight CursorLine ' . l:cur_cursorline
+  endif
+  if !empty(l:cur_cursorcolumn)
+    execute 'highlight CursorColumn ' . l:cur_cursorcolumn
+  endif
 endfunction
 
 

--- a/plugin/vim-ping-cursor.vim
+++ b/plugin/vim-ping-cursor.vim
@@ -16,23 +16,25 @@ if !exists('g:ping_cursor_flash_milliseconds')
 endif
 
 function! s:PingCursor()
-  " Save current CursorLine and CursorColumn attributes
-  let l:cur_cursorline = matchstr(execute('hi CursorLine'), 'term=.*')
-  let l:cur_cursorcolumn = matchstr(execute('hi CursorColumn'), 'term=.*')
+  if exists('g:ping_cursor_color') && !empty(g:ping_cursor_color)
+    " Save current CursorLine and CursorColumn attributes.
+    let l:cur_cursorline = matchstr(execute('hi CursorLine'), 'term=.*')
+    let l:cur_cursorcolumn = matchstr(execute('hi CursorColumn'), 'term=.*')
+    " Change the color
+    execute 'highlight CursorLine ctermbg=' . g:ping_cursor_color . ' guibg=' . g:ping_cursor_color
+    execute 'highlight CursorColumn ctermbg=' . g:ping_cursor_color . ' guibg=' . g:ping_cursor_color
+  endif
 
-  " Flash
-  highlight CursorLine ctermbg=lightblue guibg=lightblue
-  highlight CursorColumn ctermbg=lightblue guibg=lightblue
   set cursorline cursorcolumn
   redraw
   execute 'sleep' g:ping_cursor_flash_milliseconds . 'm'
   set nocursorline nocursorcolumn
 
   " Restore previous highlight attributes
-  if !empty(l:cur_cursorline)
+  if exists('l:cur_cursorline') && !empty(l:cur_cursorline)
     execute 'highlight CursorLine ' . l:cur_cursorline
   endif
-  if !empty(l:cur_cursorcolumn)
+  if exists('l:cur_cursorcolumn') && !empty(l:cur_cursorcolumn)
     execute 'highlight CursorColumn ' . l:cur_cursorcolumn
   endif
 endfunction


### PR DESCRIPTION
I like this plugin because it makes it much easier to find my cursor when I have several windows open. The commit supports changing the color of the cursor flash, making the highlight clearer in dark themes. The style remains unchanged if the global variable `g:ping_cursor_color` is not set.